### PR TITLE
return date and timestamp column types as date, timestamp and timestamptz

### DIFF
--- a/lib/postgresql.js
+++ b/lib/postgresql.js
@@ -63,7 +63,7 @@ var TYPES = {
   BOOLEAN: "boolean",
   "CHARACTER VARYING": "string",
   CHARACTER: "string",
-  DATE: "string",
+  DATE: "date",
   BIGINT: "integer",
   "DOUBLE PRECISION": "number",
   INTEGER: "integer",
@@ -75,8 +75,8 @@ var TYPES = {
   SMALLSERIAL: "integer",
   SERIAL: "integer",
   TEXT: "string",
-  "TIME WITHOUT TIME ZONE": "string",
-  "TIMESTAMP WITHOUT TIME ZONE": "string"
+  "TIME WITHOUT TIME ZONE": "timestamptz",
+  "TIMESTAMP WITHOUT TIME ZONE": "timestamp"
 }
 
 var ARRAY = /\[\]$/


### PR DESCRIPTION
Currently data and time column types for pg are returned as string column types. 
From the json returned it is not possible to deduce correct column type for data and timestamp type columns. 
This fix helps distinguish between string, date, timestamp and timestamptz column types.